### PR TITLE
fix: bot stuck on disconnect screen

### DIFF
--- a/modules/gameloop.py
+++ b/modules/gameloop.py
@@ -18,7 +18,7 @@ from modules.settings import jposition
 from modules.mouse_utils import move_mouse
 from modules.platforms import windowMP
 from modules.resolution import check_resolution
-from modules.reconnects import click_wipe_button, click_reconnect, choose_mode
+from modules.reconnects import click_wipe_button, click_reconnect, choose_mode, game_closed
 
 log = logging.getLogger(__name__)
 

--- a/modules/reconnects.py
+++ b/modules/reconnects.py
@@ -66,9 +66,9 @@ def game_closed():
     First it attempts to use psutil to kill the process;
     then it attempts OS specific commands before trying to relaunch the game.
     """
-    process_name = "hearthstone.exe"
+    process_name = "Hearthstone.exe"
     for proc in psutil.process_iter(['pid', 'name']):
-        if proc.info['name'] == process_name:
+        if proc.info['name'] == process_name or proc.info['name'] == process_name.lower():
             pid = proc.info["pid"]
             try:
                 proc.kill()


### PR DESCRIPTION
Bot stuck on disconnected screen, when i checked the mfb.log it said name "game_closed" is not defined.

i track the files, and find out that on gameloop.py you forgot to import game_closed from reconnect module.

Also, my HS process name is "Hearthstone.exe" not "hearthstone.exe"... so i think it's different on another OS? I'm not sure about it but i updated the code to check both cases.